### PR TITLE
Integrate Supabase for lead storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,6 +176,24 @@ app.get('/test-log', async (_, res) => {
   }
 });
 
+/* Temporary Supabase test route */
+app.get('/test-supabase', async (_, res) => {
+  try {
+    await logLead({
+      phone: '+15555550123',
+      address: '1 Supabase Way',
+      callTime: new Date().toISOString(),
+      tags: ['test'],
+      status: 'Testing',
+      summary: 'Supabase write test',
+      messages: [],
+    });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
 /* ----------  Start server  ---------- */
 const PORT = process.env.PORT || 5050;
 app.listen(PORT, () => console.log(`✅ Server listening on ${PORT}`));

--- a/logLead.js
+++ b/logLead.js
@@ -1,11 +1,4 @@
-import { google } from 'googleapis';
-
-const sheetsAuth = new google.auth.GoogleAuth({
-  keyFile: './service-account.json',
-  scopes: ['https://www.googleapis.com/auth/spreadsheets'],
-});
-
-const sheets = google.sheets({ version: 'v4', auth: sheetsAuth });
+import supabase from './supabaseClient.js';
 
 export async function logLead(data = {}) {
   const {
@@ -18,20 +11,19 @@ export async function logLead(data = {}) {
     messages = [],
   } = data;
 
-  const row = [
-    phone,
-    address,
-    new Date(callTime).toISOString(),
-    Array.isArray(tags) ? tags.join(',') : '',
-    status,
-    summary,
-    JSON.stringify(messages),
-  ];
-
-  await sheets.spreadsheets.values.append({
-    spreadsheetId: process.env.SHEET_ID,
-    range: 'Sheet1!A1',
-    valueInputOption: 'USER_ENTERED',
-    requestBody: { values: [row] },
-  });
+  try {
+    const { error } = await supabase.from('leads').insert({
+      phone,
+      address,
+      call_time: new Date(callTime).toISOString(),
+      tags,
+      status,
+      summary,
+      messages,
+    });
+    if (error) throw error;
+  } catch (err) {
+    console.error('Supabase insert error:', err.message || err);
+    throw err;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
       "dotenv": "^16.0.3",
       "express": "^4.18.2",
       "openai": "^4.0.0",
-    "twilio": "^4.19.0",
-    "googleapis": "^128.0.0",
-    "axios": "^1.6.7"
+      "twilio": "^4.19.0",
+      "googleapis": "^128.0.0",
+      "axios": "^1.6.7",
+      "@supabase/supabase-js": "^2.39.8"
     }
   }
   

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export default supabase;


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js` dependency
- create `supabaseClient.js` to connect to Supabase
- rewrite `logLead` to store leads in Supabase
- add `/test-supabase` route for quick testing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68517d9d4a74832d84a756511e1b5e9e