### PR TITLE
Add Twilio request validation

### DIFF
--- a/app/api/twilio/incoming/route.ts
+++ b/app/api/twilio/incoming/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { supabase } from "@/lib/supabase"
+import twilio from "twilio"
 
 // Add GET method for testing the endpoint
 export async function GET() {
@@ -16,6 +17,20 @@ export async function POST(request: NextRequest) {
 
   try {
     const formData = await request.formData()
+
+    const params: Record<string, string> = {}
+    for (const [key, value] of formData.entries()) {
+      params[key] = String(value)
+    }
+
+    const authToken = process.env.TWILIO_AUTH_TOKEN
+    const signature = request.headers.get("x-twilio-signature") || ""
+    const url = request.nextUrl.href
+
+    if (!authToken || !twilio.validateRequest(authToken, signature, url, params)) {
+      console.warn("Invalid Twilio signature for incoming message")
+      return NextResponse.json({ error: "Invalid signature" }, { status: 403 })
+    }
 
     const from = formData.get("From") as string
     const to = formData.get("To") as string

--- a/app/api/twilio/webhook/route.ts
+++ b/app/api/twilio/webhook/route.ts
@@ -1,9 +1,24 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { supabase } from "@/lib/supabase"
+import twilio from "twilio"
 
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
+
+    const params: Record<string, string> = {}
+    for (const [key, value] of formData.entries()) {
+      params[key] = String(value)
+    }
+
+    const authToken = process.env.TWILIO_AUTH_TOKEN
+    const signature = request.headers.get("x-twilio-signature") || ""
+    const url = request.nextUrl.href
+
+    if (!authToken || !twilio.validateRequest(authToken, signature, url, params)) {
+      console.warn("Invalid Twilio signature for status webhook")
+      return NextResponse.json({ error: "Invalid signature" }, { status: 403 })
+    }
 
     const messageId = formData.get("MessageSid") as string
     const messageStatus = formData.get("MessageStatus") as string


### PR DESCRIPTION
## Summary
- validate Twilio requests for incoming SMS and status webhooks

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688284cc2e24832da8bedfb919fc754d